### PR TITLE
add shared lib libpostproc.so to PLIST

### DIFF
--- a/cross/ffmpeg/PLIST
+++ b/cross/ffmpeg/PLIST
@@ -16,6 +16,9 @@ lib:lib/libavformat.so.56.40.101
 lnk:lib/libavutil.so
 lnk:lib/libavutil.so.54
 lib:lib/libavutil.so.54.31.100
+lnk:lib/libpostproc.so
+lnk:lib/libpostproc.so.53
+lib:lib/libpostproc.so.53.3.100
 lnk:lib/libswresample.so
 lnk:lib/libswresample.so.1
 lib:lib/libswresample.so.1.2.101


### PR DESCRIPTION
ffmpeg 2.8.5 was failing to run on my DS1813+ due to this missing shared lib, package was still compiling without it. Added to PLIST and ffmpeg now runs fine.
