### PR TITLE
Fixed tor build

### DIFF
--- a/cross/tor/Makefile
+++ b/cross/tor/Makefile
@@ -12,12 +12,19 @@ COMMENT  = Tor is free software for enabling anonymous communication. The name i
 LICENSE  =
 
 GNU_CONFIGURE = 1
+PRE_CONFIGURE_TARGET = generate_auto_conf
 INSTALL_TARGET = myInstall
 
 include ../../mk/spksrc.cross-cc.mk
 
 
-CONFIGURE_ARGS = --disable-asciidoc
+CONFIGURE_ARGS = --disable-asciidoc --disable-tool-name-check
+
+generate_auto_conf:
+	$(RUN) aclocal -I m4 && \
+		   autoheader && \
+		   autoconf && \
+		   automake --add-missing --copy
 
 myInstall:
 	$(RUN) make install prefix=$(STAGING_INSTALL_PREFIX) exec_prefix=$(STAGING_INSTALL_PREFIX)

--- a/spk/tor/src/service-setup.sh
+++ b/spk/tor/src/service-setup.sh
@@ -3,7 +3,7 @@ PATH="${SYNOPKG_PKGDEST}/bin:${PATH}"
 TORBIN="${SYNOPKG_PKGDEST}/bin/tor"
 TORCONF="${SYNOPKG_PKGDEST}/var/torrc"
 
-SERVICE_COMMAND="${TORBIN} -f ${TORCONF} --pidfile ${PID_FILE} --user ${USER}"
+SERVICE_COMMAND="${TORBIN} -f ${TORCONF} --pidfile ${PID_FILE}"
 
 service_postinst ()
 {


### PR DESCRIPTION
- added `--disable-tool-name-check` to CONFIGURE_ARGS for cross compilation
- added autoconf/automake invocation as PRE_CONFIGURE_TARGET to build with automake 1.4
- removed `--user ${USER}` from SERVICE_COMMAND to start as sc-tor by default
**NOTE:** if changed to `--user ${EFF_USER}` daemon cannot start because it tries to set gid of process to sc-tor but has insufficent priveleges to do so. Some tor options are available only when it's started by root

Builds for all platforms are passing except ppc853x-5.1
https://travis-ci.org/alexey-pimenov/spksrc/builds/368055216

Hope this will help to close original [PR](https://github.com/SynoCommunity/spksrc/pull/3189)